### PR TITLE
Adding the ability to ignore table/schema in the backup

### DIFF
--- a/pg_copy/management/commands/pg_backup.py
+++ b/pg_copy/management/commands/pg_backup.py
@@ -40,7 +40,13 @@ from ...settings import get_backup_path
     ),
     help="The filename of the output backup file.",
 )
-def command(database, db_override, host_override, pg_home, filename):
+@click.option(
+    "--ignore-table",
+    "ignore_tables",
+    default=None,
+    help="comma separated list of tables to ignroe.",
+)
+def command(database, db_override, host_override, pg_home, filename, ignore_tables):
     """
     Django management command to make a backup of a PostgreSQL database.
     """
@@ -48,6 +54,12 @@ def command(database, db_override, host_override, pg_home, filename):
     db = db_override or settings.DATABASES[database]["NAME"]
     host = host_override or settings.DATABASES[database]["HOST"]
     pg_dump = os.path.join(pg_home, "bin", "pg_dump") if pg_home else "pg_dump"
+
+    if ignore_tables:
+        tables = ignore_tables.split(",")
+        ignore_cmds = " "
+        for table in tables:
+               ignore_cmds = ignore_cmds + "-T {} ".format(table)
 
     click.secho(
         "Backing up database '{database}' on host '{host}' to file '{file}'...".format(
@@ -61,7 +73,7 @@ def command(database, db_override, host_override, pg_home, filename):
 
     os.environ["PGPASSWORD"] = settings.DATABASES[database]["PASSWORD"]
     os.system(
-        "{pg_dump} -Fc -c -x -h {host} -U {username} --file={file} {database}".format(
+        "{pg_dump} -Fc -c -x -h {host} -U {username} {ignore_cmds }--file={file} {database}".format(
             pg_dump=pg_dump,
             host=host,
             username=settings.DATABASES[database]["USER"],

--- a/pg_copy/management/commands/pg_backup.py
+++ b/pg_copy/management/commands/pg_backup.py
@@ -41,12 +41,13 @@ from ...settings import get_backup_path
     help="The filename of the output backup file.",
 )
 @click.option(
-    "--ignore-tables",
-    "ignore_tables",
-    default=None,
-    help="comma separated list of tables to ignroe.",
+    "--ignore-table",
+    "ignore_table",
+    multiple=True,
+    default=[],
+    help="Table/Schema to ignore during backup file creation.",
 )
-def command(database, db_override, host_override, pg_home, filename, ignore_tables):
+def command(database, db_override, host_override, pg_home, filename, ignore_table):
     """
     Django management command to make a backup of a PostgreSQL database.
     """
@@ -55,11 +56,9 @@ def command(database, db_override, host_override, pg_home, filename, ignore_tabl
     host = host_override or settings.DATABASES[database]["HOST"]
     pg_dump = os.path.join(pg_home, "bin", "pg_dump") if pg_home else "pg_dump"
 
-    if ignore_tables:
-        tables = ignore_tables.split(",")
-        ignore_cmds = " "
-        for table in tables:
-               ignore_cmds = ignore_cmds + "-T {} ".format(table)
+    ignore_table_cmd = " "
+    for table in ignore_table:
+        ignore_table_cmd  = ignore_table_cmd + "-T {} ".format(table)
 
     click.secho(
         "Backing up database '{database}' on host '{host}' to file '{file}'...".format(
@@ -73,11 +72,11 @@ def command(database, db_override, host_override, pg_home, filename, ignore_tabl
 
     os.environ["PGPASSWORD"] = settings.DATABASES[database]["PASSWORD"]
     os.system(
-        "{pg_dump} -Fc -c -x -h {host} -U {username} {ignore_cmds}--file={file} {database}".format(
+        "{pg_dump} -Fc -c -x -h {host} -U {username} {ignore_table_cmd} --file={file} {database}".format(
             pg_dump=pg_dump,
             host=host,
             username=settings.DATABASES[database]["USER"],
-            ignore_cmds=ignore_cmds,
+            ignore_table_cmd =ignore_table_cmd ,
             database=db,
             file=filename,
         )

--- a/pg_copy/management/commands/pg_backup.py
+++ b/pg_copy/management/commands/pg_backup.py
@@ -41,7 +41,7 @@ from ...settings import get_backup_path
     help="The filename of the output backup file.",
 )
 @click.option(
-    "--ignore-table",
+    "--ignore-tables",
     "ignore_tables",
     default=None,
     help="comma separated list of tables to ignroe.",

--- a/pg_copy/management/commands/pg_backup.py
+++ b/pg_copy/management/commands/pg_backup.py
@@ -73,10 +73,11 @@ def command(database, db_override, host_override, pg_home, filename, ignore_tabl
 
     os.environ["PGPASSWORD"] = settings.DATABASES[database]["PASSWORD"]
     os.system(
-        "{pg_dump} -Fc -c -x -h {host} -U {username} {ignore_cmds }--file={file} {database}".format(
+        "{pg_dump} -Fc -c -x -h {host} -U {username} {ignore_cmds}--file={file} {database}".format(
             pg_dump=pg_dump,
             host=host,
             username=settings.DATABASES[database]["USER"],
+            ignore_cmds=ignore_cmds,
             database=db,
             file=filename,
         )


### PR DESCRIPTION
Use Case:
When a database has user tracking/logging it can inflate the database size in a way that is not needed for application development.
This will allow a developer to ignore a given table if they do not need it for development.

Example of usage:
` ./manage.py pg_backup --settings=config.settings.prod --ignore-tables=request_request`

Reference:
https://stackoverflow.com/questions/40642359/ignoring-a-table-in-pg-dump-and-restore
